### PR TITLE
package.json: remove npm requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   ],
   "engineStrict": false,
   "engines": {
-    "npm": "^5.0.4",
     "node": ">=8.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
It gives a warning on newer versions of npm even though it is compatible:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'react-jsonschema-form-extras@0.9.73',
npm WARN EBADENGINE   required: { node: '>=8.0.0', npm: '^5.0.4' },
npm WARN EBADENGINE   current: { node: 'v16.17.0', npm: '8.15.0' }
npm WARN EBADENGINE }
```

I therefore removed the `npm` version requirement.